### PR TITLE
change the way to get right FP gacha subId

### DIFF
--- a/libs/GetSubGachaId.py
+++ b/libs/GetSubGachaId.py
@@ -1,22 +1,53 @@
+from typing import List
+
 import requests
-import json
 
 from mytime import GetTimeStamp
 
-# Get Friend Summon Gacha Sub Id
-def GetGachaSubIdFP(region):
-    response = requests.get(f"https://git.atlasacademy.io/atlasacademy/fgo-game-data/raw/branch/{region}/master/mstGachaSub.json");
-    gachaList = json.loads(response.text)
-    timeNow = GetTimeStamp()
-    priority = 0
-    goodGacha = {}
-    for gacha in gachaList:
-        openedAt = gacha["openedAt"]
-        closedAt = gacha["closedAt"]
 
-        if openedAt <= timeNow & timeNow <= closedAt:
-            p = int(gacha["priority"])
-            if(p > priority):
-                priority = p
-                goodGacha = gacha
-    return str(goodGacha["id"])
+def isMatchedQuestCondition(region: str, userQuest: List, commonReleaseId: int):
+    api = f"https://api.atlasacademy.io/nice/{region}/common-release/{commonReleaseId}"
+    response = requests.get(api)
+    response.raise_for_status()
+    condition = response.json()
+    if len(condition) > 0 and condition[0].get("condType", "") == "questClear":
+        for quest in userQuest:
+            condQuestId = condition[0]["condId"]
+            condClearNum = condition[0]["condNum"]
+            # Don't know quest["clearNum"] equl condClearNum is fine or not
+            if quest["questId"] == condQuestId and quest["clearNum"] > condClearNum:
+                return True
+            elif quest["questId"] == condQuestId and quest["clearNum"] <= condClearNum:
+                return False
+        return False
+    else:
+        # please implement webhook sned error or etc here
+        pass
+
+
+# Get Friend Summon Gacha Sub Id
+def GetGachaSubIdFP(region, userQuest: List = []):
+    api = f"https://git.atlasacademy.io/atlasacademy/fgo-game-data/raw/branch/{region}/master/mstGachaSub.json"
+    response = requests.get(api)
+    data = list(response.json())
+    data.reverse()
+
+    timeNow = GetTimeStamp()
+    actiaveGacha = []
+    for gacha in data:
+        if gacha["closedAt"] > timeNow and gacha["openedAt"] < timeNow:
+            actiaveGacha.append(gacha)
+        else:
+            break
+
+    if len(actiaveGacha) == 0:
+        # please implement webhook sned error or etc here
+        pass
+
+    # Start by sorting from highest to lowest priority, then within the same priority, sort by commonReleaseId
+    sortedGachaList = sorted(actiaveGacha, key=lambda x: (x["priority"], x["commonReleaseId"]), reverse=True)
+    for gacha in sortedGachaList:
+        if gacha["commonReleaseId"] != 0 and isMatchedQuestCondition(region, userQuest, gacha["commonReleaseId"]):
+            return gacha["id"]
+        elif gacha["commonReleaseId"] == 0:
+            return gacha["id"]

--- a/user.py
+++ b/user.py
@@ -468,13 +468,13 @@ class user:
         self.builder_.AddParameter('shopIdIndex', '1')
 
         if main.fate_region == "NA":
-            gachaSubId = GetGachaSubIdFP("NA")
+            gachaSubId = GetGachaSubIdFP("NA", self.userQuest)
             if gachaSubId is None:
                 gachaSubId = "0" 
             self.builder_.AddParameter('gachaSubId', gachaSubId)
             main.logger.info(f"\n ======================================== \n [+] 召唤卡池GachaSubId ： {gachaSubId} \n ======================================== " )
         else:
-            gachaSubId = GetGachaSubIdFP("JP")
+            gachaSubId = GetGachaSubIdFP("JP", self.userQuest)
             if gachaSubId is None:
                 gachaSubId = "0" 
             self.builder_.AddParameter('gachaSubId', gachaSubId)

--- a/user.py
+++ b/user.py
@@ -130,6 +130,7 @@ class user:
         self.user_id_ = (int)(user_id)
         self.s_ = fgourl.NewSession()
         self.builder_ = ParameterBuilder(user_id, auth_key, secret_key)
+        self.userQuest = []
 
     def Post(self, url):
         res = fgourl.PostReq(self.s_, url, self.builder_.Build())
@@ -399,6 +400,9 @@ class user:
         )
 
         DataWebhook.append(login)
+
+        for questInfo in data['cache']['replaced'].get('userQuest', []):
+            self.userQuest.append(questInfo)  # can implement a paydantic model here
 
         if 'seqLoginBonus' in data['response'][0]['success']:
             bonus_message = data['response'][0]['success']['seqLoginBonus'][0]['message']

--- a/user.py
+++ b/user.py
@@ -477,7 +477,7 @@ class user:
             gachaSubId = GetGachaSubIdFP("JP", self.userQuest)
             if gachaSubId is None:
                 gachaSubId = "0" 
-            self.builder_.AddParameter('gachaSubId', gachaSubId)
+            self.builder_.AddParameter('gachaSubId', str(gachaSubId))
             main.logger.info(f"\n ======================================== \n [+] 召唤卡池GachaSubId ： {gachaSubId} \n ======================================== " )
 
         data = self.Post(


### PR DESCRIPTION
Objects with commonReleaseId within the same level of high priority are checked first. 
If all conditions of the high priority are present but not met, then the next priority level is checked. 
The only condition that is currently being checked is 'clearQuest' and 'clearNum'